### PR TITLE
feat: Add support for a custom server path

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,6 +58,11 @@
           "type": "boolean",
           "default": false
         },
+        "lua.serverPath": {
+          "description": "Path to lua-language-server executable (points to bundled binary by default). If set, then checkForUpdates has no effect.",
+          "type": "string",
+          "default": ""
+        },
         "lua.trace.server": {
           "type": "string",
           "default": "off",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -13,7 +13,7 @@ export async function activate(context: ExtensionContext): Promise<void> {
     return
   }
 
-  if (config.checkForUpdates !== "disabled") {
+  if (config.checkForUpdates !== "disabled" && config.serverPath.length === 0) {
     setTimeout(() => checkForUpdate(config.checkForUpdates), 0)
   }
 

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -6,6 +6,7 @@ import { workspace } from "coc.nvim"
 interface LuaConfig {
   enable: boolean
   checkForUpdates: "disabled" | "inform" | "ask" | "install"
+  serverPath: string
   installPreReleases: boolean
 }
 

--- a/src/utils/installer.ts
+++ b/src/utils/installer.ts
@@ -161,7 +161,12 @@ export async function luaLsCommandAndArgs(): Promise<[string, string[]]> {
   const baseDir = await configDir(luaLsDir)
 
   const { bin } = osEnv()
-  return [path.join(baseDir, bin), ["-E", path.join(baseDir, "main.lua")]]
+  const { serverPath } = getConfig()
+
+  return [
+    serverPath.length > 0 ? serverPath : path.join(baseDir, bin),
+    ["-E", path.join(baseDir, "main.lua")],
+  ]
 }
 
 async function luaLsExists(): Promise<boolean> {


### PR DESCRIPTION
This PR allows for a custom language server executable, which seems to be necessary on NixOS as the bundled binary doesn't work (hardcoded dynamic linking woes).
